### PR TITLE
Bump to 1.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "bluesky" %}
-{% set version = "1.5.7" %}
-{% set sha256 = "1a999b6c89907ec5c246fa4b6920c75acb14a15bc794157dbdfcbc6959390efd" %}
+{% set version = "1.6.1" %}
+{% set sha256 = "c6fb9e8b87893b1ea28f8c2b048cd07eef2d21f273bbabdc57b969c342806ebc" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
- [x] No changes in deps since 1.6.0
- [x] Build number is 0

Note that https://github.com/nsls-ii-forge/bluesky-feedstock/pull/10 moved the
verions *backward* from 1.6.0 to 1.5.7 but it did not update the deps,
so no changes are needed to move the deps back.