### PR TITLE
v1.5.9 no upload on branch test

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -13,4 +13,3 @@ provider:
   linux: azure
   osx: azure
   win: azure
-upload_on_branch: v1.5.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 9999
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:


### PR DESCRIPTION
Right now, https://github.com/nsls-ii-forge/bluesky-feedstock/blob/v1.5.x/.azure-pipelines/azure-pipelines-linux.yml does not contain `UPLOAD_ON_BRANCH` variable defined. I expect the upload will happen even before the PR is merged.

cc @jklynch 